### PR TITLE
Support multi inputs for webnn EP

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/model.cc
+++ b/onnxruntime/core/providers/webnn/builders/model.cc
@@ -74,5 +74,21 @@ const OnnxTensorInfo& Model::GetInputOutputInfo(const std::string& name) const {
   return input_output_info_.at(name);
 }
 
+void Model::SetInputMap(std::unordered_map<std::string, size_t>&& input_map) {
+  input_map_ = std::move(input_map);
+}
+
+void Model::SetOutputMap(std::unordered_map<std::string, size_t>&& output_map) {
+  output_map_ = std::move(output_map);
+}
+
+size_t Model::GetMappedInputIdx(const std::string& name) const {
+  return input_map_.at(name);
+}
+
+size_t Model::GetMappedOutputIdx(const std::string& name) const {
+  return output_map_.at(name);
+}
+
 }  // namespace webnn
 }  // namespace onnxruntime

--- a/onnxruntime/core/providers/webnn/builders/model.h
+++ b/onnxruntime/core/providers/webnn/builders/model.h
@@ -45,6 +45,15 @@ class Model {
 
   const OnnxTensorInfo& GetInputOutputInfo(const std::string& name) const;
 
+  // Set the mapping between input/output name and ORT kernel context
+  // input/output index, at execution time
+  void SetInputMap(std::unordered_map<std::string, size_t>&& input_map);
+  void SetOutputMap(std::unordered_map<std::string, size_t>&& output_map);
+
+  // Get the ORT kernel context input/output index with given name
+  size_t GetMappedInputIdx(const std::string& name) const;
+  size_t GetMappedOutputIdx(const std::string& name) const;
+
  private:
   ::ml::Graph graph_;
   const logging::Logger& logger_;
@@ -60,6 +69,9 @@ class Model {
   std::vector<std::string> outputs_;
 
   std::unordered_map<std::string, OnnxTensorInfo> input_output_info_;
+
+  std::unordered_map<std::string, size_t> input_map_;
+  std::unordered_map<std::string, size_t> output_map_;
 
   OrtMutex mutex_;
 


### PR DESCRIPTION
**Description**: Describe your changes.
Support multi inputs for webnn EP.

**Motivation and Context**
- Why is this change required? What problem does it solve?
Build a map of inputName and index from <FusedNodeAndGraph> and get the index of the model input from the map according to the name when calling `ort.KernelContext_GetInput`.

- If it fixes an open issue, please link to the issue here.
webnn-native [issue961](https://github.com/otcshare/webnn-native/issues/961)
