### PR TITLE
Track the dynamic dim of the Reshape op using rational arithmetic

### DIFF
--- a/onnxruntime/core/providers/webnn/builders/helper.h
+++ b/onnxruntime/core/providers/webnn/builders/helper.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstring>
+#include <optional>
 #include <core/common/status.h>
 #include "core/common/inlined_containers.h"
 #include <core/graph/basic_types.h>
@@ -33,6 +34,76 @@ struct FreeDimensionBound {
 };
 
 using FreeDimensionBounds = InlinedHashMap<std::string, FreeDimensionBound>;
+
+// Compute the greatest common divisor of two non-negative integers.
+inline int64_t Gcd(int64_t a, int64_t b) {
+  a = std::abs(a);
+  b = std::abs(b);
+  while (b) {
+    a %= b;
+    std::swap(a, b);
+  }
+  return a;
+}
+
+// Tracks dynamic dimension info produced by Reshape ops.
+// For graph inputs, numerator=1, denominator=1, and base_name is the original dim_param.
+// For Reshape-derived dims, numerator/denominator reflects the rational scaling factor.
+// current_dim = base * numerator / denominator.
+// E.g., sequence_length (1/1) -> reshape x8 -> sequence_length_x8 (8/1)
+//     -> reshape /8 -> sequence_length (1/1).
+// Also handles contraction: sequence_length (1/1) -> reshape /8 -> sequence_length_d8 (1/8).
+struct DynamicDimInfo {
+  std::string base_name;  // Original dim_param, e.g. "sequence_length".
+  int32_t numerator;      // Rational scale numerator: current = base * numerator / denominator.
+  int32_t denominator;    // Rational scale denominator (always > 0).
+  int32_t base_min;       // Base dimension's min bound (from FreeDimensionBounds).
+  int32_t base_max;       // Base dimension's max bound (from FreeDimensionBounds).
+
+  int32_t CurrentMin() const {
+    return static_cast<int32_t>(static_cast<int64_t>(base_min) * numerator / denominator);
+  }
+  int32_t CurrentMax() const {
+    return static_cast<int32_t>(static_cast<int64_t>(base_max) * numerator / denominator);
+  }
+
+  // Return the WebNN dynamic dimension name.
+  // 1/1 -> "sequence_length", 8/1 -> "sequence_length_x8", 1/8 -> "sequence_length_d8".
+  std::string DimName() const {
+    if (numerator == 1 && denominator == 1) return base_name;
+    if (denominator == 1) return base_name + "_x" + std::to_string(numerator);
+    if (numerator == 1) return base_name + "_d" + std::to_string(denominator);
+    return base_name + "_x" + std::to_string(numerator) + "d" + std::to_string(denominator);
+  }
+
+  // Simplify the rational number in-place using GCD.
+  void Simplify() {
+    int64_t g = Gcd(numerator, denominator);
+    if (g > 1) {
+      numerator = static_cast<int32_t>(numerator / g);
+      denominator = static_cast<int32_t>(denominator / g);
+    }
+  }
+
+  // Create a simplified DynamicDimInfo from int64_t numerator/denominator,
+  // reducing via GCD before narrowing to int32_t to avoid overflow.
+  static DynamicDimInfo CreateSimplified(const std::string& base_name,
+                                         int64_t num, int64_t den,
+                                         int32_t base_min, int32_t base_max) {
+    int64_t g = Gcd(num, den);
+    if (g > 1) {
+      num /= g;
+      den /= g;
+    }
+    return DynamicDimInfo{base_name,
+                          static_cast<int32_t>(num),
+                          static_cast<int32_t>(den),
+                          base_min, base_max};
+  }
+};
+
+// Per-operand dynamic dimension info: one optional entry per axis.
+using OperandDimInfo = std::vector<std::optional<DynamicDimInfo>>;
 
 enum class WebnnDeviceType {
   CPU,

--- a/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/base_op_builder.cc
@@ -21,6 +21,39 @@ Status BaseOpBuilder::AddToModelBuilder(ModelBuilder& model_builder, const Node&
                     model_builder.GetOpSupportLimits(), logger),
       "Unsupported operator ", node.OpType());
   ORT_RETURN_IF_ERROR(AddToModelBuilderImpl(model_builder, node, logger));
+
+  // Auto-propagate dynamic dimension info through shape-preserving operations.
+  // If the first input has dim info and the first output does not yet have dim info,
+  // and the output has the same rank as the input, copy the dim info to the output.
+  // This enables Reshape chains separated by ops like LayerNorm, Add, etc. to work.
+  //
+  // TODO: Current limitations:
+  // - Only propagates from the first input (input_defs[0]). For binary ops like Add(A, B),
+  //   if only B carries dim info, it won't be propagated.
+  // - Only sets dim info on the first output (output_defs[0]). Multi-output ops like
+  //   SkipSimplifiedLayerNormalization may need dim info on additional outputs.
+  // - Does not handle rank-changing ops (Squeeze, Unsqueeze, Flatten, etc.). Those ops
+  //   would need custom dim info logic in their respective op builders.
+  // - Axis-reordering ops (e.g., Transpose) have the same rank but permute axis semantics.
+  //   Blindly copying dim info would assign dynamic dims to wrong axes.
+  const auto& input_defs = node.InputDefs();
+  const auto& output_defs = node.OutputDefs();
+  if (!input_defs.empty() && !output_defs.empty() &&
+      input_defs[0]->Name() != "" && output_defs[0]->Name() != "") {
+    const auto* input_dim_info = model_builder.GetOperandDimInfo(input_defs[0]->Name());
+    if (input_dim_info != nullptr &&
+        model_builder.GetOperandDimInfo(output_defs[0]->Name()) == nullptr) {
+      // Check that the output has the same rank as the input dim info.
+      const auto* output_shape = output_defs[0]->Shape();
+      if (output_shape != nullptr &&
+          static_cast<size_t>(output_shape->dim_size()) == input_dim_info->size()) {
+        // Copy dim info from input to output (shape-preserving op).
+        OperandDimInfo output_dim_info(*input_dim_info);
+        model_builder.SetOperandDimInfo(output_defs[0]->Name(), std::move(output_dim_info));
+      }
+    }
+  }
+
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/impl/reshape_op_builder.cc
@@ -46,6 +46,22 @@ Status ReshapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
   const auto& target_shape_tensor_dims = target_shape_tensor.dims();
   emscripten::val input = model_builder.GetOperand(input_defs[0]->Name());
   emscripten::val new_shape = emscripten::val::array();
+
+  const std::string& input_name = input_defs[0]->Name();
+  const std::string& output_name = node.OutputDefs()[0]->Name();
+
+  // Retrieve per-axis dynamic dim info for the input operand (may be nullptr if fully static).
+  const OperandDimInfo* input_dim_info = model_builder.GetOperandDimInfo(input_name);
+
+  // Fallback: if no dim info was propagated (e.g., due to rank changes between graph input and here),
+  // try to construct it directly from the input's ONNX shape proto + FreeDimensionBounds.
+  OperandDimInfo constructed_dim_info;
+  if (input_dim_info == nullptr) {
+    if (model_builder.BuildDimInfoFromNodeArg(*input_defs[0], constructed_dim_info)) {
+      input_dim_info = &constructed_dim_info;
+    }
+  }
+
   // Do nothing if target shape is an empty shape, which means converting to a scalar.
   if (!target_shape_tensor_dims.empty()) {
     const int64_t* raw_target_shape = target_shape_tensor.int64_data().empty()
@@ -53,19 +69,212 @@ Status ReshapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
                                           : target_shape_tensor.int64_data().data();
 
     const auto size = target_shape_tensor_dims[0];
-    TensorShapeVector target_shape{raw_target_shape, raw_target_shape + size};
     std::vector<int64_t> input_shape;
     ORT_RETURN_IF_NOT(GetShape(*input_defs[0], input_shape, logger), "Cannot get shape");
-    ReshapeHelper helper(TensorShape(input_shape), target_shape);
 
-    for (size_t axis = 0; axis < static_cast<size_t>(size); ++axis) {
-      if (target_shape[axis] == 0) {
-        // WebNN reshape does not accept literal 0 in new shape.
-        // Follow ONNX allowzero=0 semantics by copying from input shape at the same axis.
-        new_shape.call<void>("push", input["shape"][axis]);
-      } else {
-        uint32_t dim_value = SafeInt<uint32_t>(target_shape[axis]);
-        new_shape.call<void>("push", dim_value);
+    // Check if input has any dynamic dimensions.
+    bool has_dynamic_input = input_dim_info != nullptr;
+
+    if (has_dynamic_input) {
+      // Dynamic path: handle 0, static, and -1 axes with dynamic dimension tracking
+      // 1. For each input axis: classify as 0-consumed (by a target 0 axis), static, or dynamic.
+      //    Multiply static input dims into static_input_product.
+      //    There should be exactly one dynamic input dim contributing to the -1 output axis.
+      // 2. For each output axis: classify as 0 (pass-through from input), static, or -1 (infer).
+      //    Multiply static output dims into static_output_product.
+      // 3. R = static_input_product / static_output_product.
+      // 4. For the -1 axis, new_multiplier = old_multiplier * R (expansion) or old_multiplier / R (contraction).
+      // 5. Build the WebNN dynamic dimension descriptor and register derived dim info.
+
+      int64_t static_input_product = 1;
+      int64_t static_output_product = 1;
+      int minus_one_axis = -1;
+      // Track which dynamic dim from input contributes to -1 axis.
+      const DynamicDimInfo* contributing_dyn_dim = nullptr;
+      int contributing_dyn_count = 0;
+
+      // Pass 1: Classify input axes.
+      // Build a set of axes consumed by 0 in target shape.
+      InlinedHashSet<size_t> zero_consumed_axes;
+      for (int64_t i = 0; i < size; ++i) {
+        if (raw_target_shape[i] == 0 && i < static_cast<int64_t>(input_shape.size())) {
+          zero_consumed_axes.insert(static_cast<size_t>(i));
+        }
+      }
+
+      for (size_t i = 0; i < input_shape.size(); ++i) {
+        if (zero_consumed_axes.count(i)) {
+          // This axis is consumed by a 0 in target: its value (static or dynamic) passes through.
+          continue;
+        }
+        bool is_dyn = (input_dim_info->size() > i && (*input_dim_info)[i].has_value());
+        if (is_dyn) {
+          contributing_dyn_dim = &(*input_dim_info)[i].value();
+          contributing_dyn_count++;
+        } else {
+          // Static input axis (input_shape[i] should be > 0).
+          ORT_RETURN_IF(input_shape[i] <= 0,
+                        "Unexpected non-positive static input dim at axis ", i);
+          static_input_product *= input_shape[i];
+        }
+      }
+
+      // Pass 2: Classify output axes.
+      for (int64_t i = 0; i < size; ++i) {
+        if (raw_target_shape[i] == 0) {
+          // Pass-through from input (handled separately).
+        } else if (raw_target_shape[i] == -1) {
+          minus_one_axis = static_cast<int>(i);
+        } else {
+          static_output_product *= raw_target_shape[i];
+        }
+      }
+
+      // Build output dim info.
+      OperandDimInfo output_dim_info(static_cast<size_t>(size), std::nullopt);
+
+      // Populate dim info for 0 (pass-through) axes.
+      for (int64_t i = 0; i < size; ++i) {
+        if (raw_target_shape[i] == 0) {
+          if (input_dim_info->size() > static_cast<size_t>(i) &&
+              (*input_dim_info)[static_cast<size_t>(i)].has_value()) {
+            output_dim_info[static_cast<size_t>(i)] = (*input_dim_info)[static_cast<size_t>(i)];
+          }
+        }
+      }
+
+      // Handle the -1 axis.
+      if (minus_one_axis >= 0) {
+        if (contributing_dyn_count == 0) {
+          // All input dims feeding -1 are static. Nothing to set in output_dim_info.
+        } else if (contributing_dyn_count == 1 && contributing_dyn_dim != nullptr) {
+          // Exactly one dynamic dim contributing: compute the rational ratio.
+          // new = old_num/old_den * static_input_product / static_output_product
+          //     = (old_num * static_input_product) / (old_den * static_output_product)
+          ORT_RETURN_IF(static_output_product == 0, "static_output_product is zero, cannot compute -1 axis");
+
+          int64_t new_num64 = static_cast<int64_t>(contributing_dyn_dim->numerator) * static_input_product;
+          int64_t new_den64 = static_cast<int64_t>(contributing_dyn_dim->denominator) * static_output_product;
+          ORT_RETURN_IF(new_den64 == 0, "Computed zero denominator for -1 axis");
+
+          // Simplify via GCD before narrowing to int32_t to prevent overflow.
+          DynamicDimInfo new_dim = DynamicDimInfo::CreateSimplified(
+              contributing_dyn_dim->base_name, new_num64, new_den64,
+              contributing_dyn_dim->base_min, contributing_dyn_dim->base_max);
+
+          // Validate that the resulting dimension produces integer values.
+          ORT_RETURN_IF(new_dim.numerator <= 0 || new_dim.denominator <= 0,
+                        "Computed non-positive rational scale for -1 axis: ",
+                        new_dim.numerator, "/", new_dim.denominator);
+          ORT_RETURN_IF((static_cast<int64_t>(new_dim.base_min) * new_dim.numerator) % new_dim.denominator != 0,
+                        "Dynamic dim min (", new_dim.base_min,
+                        ") not divisible by scale denominator (", new_dim.denominator, ")");
+          ORT_RETURN_IF((static_cast<int64_t>(new_dim.base_max) * new_dim.numerator) % new_dim.denominator != 0,
+                        "Dynamic dim max (", new_dim.base_max,
+                        ") not divisible by scale denominator (", new_dim.denominator, ")");
+
+          output_dim_info[static_cast<size_t>(minus_one_axis)] = std::move(new_dim);
+        } else {
+          // Multiple dynamic dims contributing to -1.
+          return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_ARGUMENT,
+                                 "Reshape with -1 axis: multiple dynamic input dimensions (",
+                                 contributing_dyn_count, ") contributing is not supported");
+        }
+      }
+
+      // Build new_shape in correct order.
+      // Cache the output shape proto for resolving real dim_param names.
+      const auto* output_shape_proto = node.OutputDefs()[0]->Shape();
+
+      // Helper: resolve the WebNN dimension name for a given axis.
+      // Prefers the real ONNX dim_param if available, otherwise uses DimName().
+      auto resolve_dim_name = [output_shape_proto](const DynamicDimInfo& dim, int axis) -> std::string {
+        if (output_shape_proto != nullptr &&
+            axis < output_shape_proto->dim_size() &&
+            !output_shape_proto->dim(axis).has_dim_value() &&
+            !output_shape_proto->dim(axis).dim_param().empty()) {
+          return output_shape_proto->dim(axis).dim_param();
+        }
+        return dim.DimName();
+      };
+
+      // Helper: push an MLDynamicDimension descriptor for a dynamic axis.
+      auto push_dynamic_dim = [&new_shape, &resolve_dim_name](const DynamicDimInfo& dim, int axis) {
+        emscripten::val dim_obj = emscripten::val::object();
+        dim_obj.set("name", emscripten::val(resolve_dim_name(dim, axis)));
+        dim_obj.set("minSize", dim.CurrentMin());
+        dim_obj.set("maxSize", dim.CurrentMax());
+        new_shape.call<void>("push", dim_obj);
+      };
+
+      for (int64_t i = 0; i < size; ++i) {
+        if (raw_target_shape[i] == 0) {
+          // Pass-through from input. If this axis is dynamic, we must push an MLDynamicDimension
+          // descriptor because input["shape"][i] returns 0 for dynamic dims in WebNN.
+          if (output_dim_info[static_cast<size_t>(i)].has_value()) {
+            push_dynamic_dim(output_dim_info[static_cast<size_t>(i)].value(), static_cast<int>(i));
+          } else {
+            new_shape.call<void>("push", input["shape"][static_cast<int>(i)]);
+          }
+        } else if (raw_target_shape[i] == -1) {
+          if (minus_one_axis >= 0 && output_dim_info[static_cast<size_t>(i)].has_value()) {
+            push_dynamic_dim(output_dim_info[static_cast<size_t>(i)].value(), static_cast<int>(i));
+          } else {
+            // Static -1 axis: compute the inferred value.
+            ORT_RETURN_IF(static_output_product == 0, "static_output_product is zero");
+            int64_t inferred = static_input_product / static_output_product;
+            new_shape.call<void>("push", SafeInt<uint32_t>(inferred));
+          }
+        } else {
+          uint32_t dim_value = SafeInt<uint32_t>(raw_target_shape[i]);
+          new_shape.call<void>("push", dim_value);
+        }
+      }
+
+      // Register output dim info if it has any dynamic dimensions.
+      bool has_output_dynamic = false;
+      for (const auto& d : output_dim_info) {
+        if (d.has_value()) {
+          has_output_dynamic = true;
+          break;
+        }
+      }
+      if (has_output_dynamic) {
+        model_builder.SetOperandDimInfo(output_name, std::move(output_dim_info));
+      }
+    } else {
+      // Safety check: verify the input is truly fully static. If the input actually has
+      // dynamic dimensions but we have no dim info, the static path would produce incorrect results.
+      // Fail explicitly rather than silently computing wrong shapes.
+      if (std::any_of(input_shape.begin(), input_shape.end(), [](int64_t d) { return d <= 0; })) {
+        bool target_needs_dynamic = false;
+        for (int64_t i = 0; i < size; ++i) {
+          if (raw_target_shape[i] == 0 || raw_target_shape[i] == -1) {
+            target_needs_dynamic = true;
+            break;
+          }
+        }
+        if (target_needs_dynamic) {
+          return ORT_MAKE_STATUS(ONNXRUNTIME, FAIL,
+                                 "Reshape node '", node.Name(), "': input '", input_name,
+                                 "' has dynamic dimensions but no dimension tracking info is available. "
+                                 "This may happen when dimension info propagation is broken by rank-changing "
+                                 "operations between two Reshapes. Ensure FreeDimensionBounds are configured "
+                                 "for all base dynamic dimensions, or add custom dim info propagation for "
+                                 "the intermediate rank-changing operation.");
+        }
+      }
+
+      TensorShapeVector target_shape{raw_target_shape, raw_target_shape + size};
+      ReshapeHelper helper(TensorShape(input_shape), target_shape);
+
+      for (size_t axis = 0; axis < static_cast<size_t>(size); ++axis) {
+        if (target_shape[axis] == 0) {
+          new_shape.call<void>("push", input["shape"][axis]);
+        } else {
+          uint32_t dim_value = SafeInt<uint32_t>(target_shape[axis]);
+          new_shape.call<void>("push", dim_value);
+        }
       }
     }
   }
@@ -80,7 +289,7 @@ Status ReshapeOpBuilder::AddToModelBuilderImpl(ModelBuilder& model_builder,
                                                                             input,
                                                                             new_shape,
                                                                             options);
-  model_builder.AddOperand(node.OutputDefs()[0]->Name(), std::move(output));
+  model_builder.AddOperand(output_name, std::move(output));
   return Status::OK();
 }
 

--- a/onnxruntime/core/providers/webnn/builders/model_builder.cc
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.cc
@@ -246,6 +246,35 @@ Status ModelBuilder::RegisterInitializers() {
   return Status::OK();
 }
 
+void ModelBuilder::SetOperandDimInfo(const std::string& name, OperandDimInfo&& dim_info) {
+  operand_dim_info_map_[name] = std::move(dim_info);
+}
+
+const OperandDimInfo* ModelBuilder::GetOperandDimInfo(const std::string& name) const {
+  auto it = operand_dim_info_map_.find(name);
+  return it != operand_dim_info_map_.end() ? &it->second : nullptr;
+}
+
+bool ModelBuilder::BuildDimInfoFromNodeArg(const NodeArg& node_arg, OperandDimInfo& dim_info) const {
+  const auto* shape_proto = node_arg.Shape();
+  if (shape_proto == nullptr) return false;
+
+  dim_info.assign(shape_proto->dim_size(), std::nullopt);
+  bool has_dynamic = false;
+  for (int i = 0; i < shape_proto->dim_size(); ++i) {
+    const auto& dim = shape_proto->dim(i);
+    if (!dim.has_dim_value() && !dim.dim_param().empty()) {
+      auto it = free_dimension_bounds_.find(dim.dim_param());
+      if (it != free_dimension_bounds_.end()) {
+        dim_info[i] = DynamicDimInfo{dim.dim_param(), 1, 1,
+                                     it->second.min_size, it->second.max_size};
+        has_dynamic = true;
+      }
+    }
+  }
+  return has_dynamic;
+}
+
 Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_input) {
   const auto& name = node_arg.Name();
   const std::string input_output_type = is_input ? "input" : "output";
@@ -365,6 +394,12 @@ Status ModelBuilder::RegisterModelInputOutput(const NodeArg& node_arg, bool is_i
     wnn_operands_.insert(std::make_pair(name, wnn_input));
     emscripten::val::module_property("webnnRegisterGraphInput")(name);
     input_names_.push_back(name);
+
+    // Build per-axis DynamicDimInfo for this input's dynamic dimensions.
+    OperandDimInfo dim_info;
+    if (BuildDimInfoFromNodeArg(node_arg, dim_info)) {
+      SetOperandDimInfo(name, std::move(dim_info));
+    }
   } else {
     if (cast_required) {
       cast_required_output_names_.push_back(name);

--- a/onnxruntime/core/providers/webnn/builders/model_builder.h
+++ b/onnxruntime/core/providers/webnn/builders/model_builder.h
@@ -65,6 +65,15 @@ class ModelBuilder {
 
   std::string GetUniqueName(const std::string& base_name);
 
+  // Dynamic dimension info tracking for Reshape-derived dimensions.
+  void SetOperandDimInfo(const std::string& name, OperandDimInfo&& dim_info);
+  const OperandDimInfo* GetOperandDimInfo(const std::string& name) const;
+  const FreeDimensionBounds& GetFreeDimensionBounds() const { return free_dimension_bounds_; }
+
+  // Build DynamicDimInfo from a NodeArg's ONNX shape proto + FreeDimensionBounds.
+  // Returns true if at least one dynamic dimension was found, populating dim_info.
+  bool BuildDimInfoFromNodeArg(const NodeArg& node_arg, OperandDimInfo& dim_info) const;
+
  private:
   const GraphViewer& graph_viewer_;
   const logging::Logger& logger_;
@@ -88,6 +97,10 @@ class ModelBuilder {
 
   std::unordered_map<std::string, int> initializer_usage_;
   InlinedHashSet<std::string> skipped_inputs_;
+
+  // Maps operand name -> per-axis dynamic dimension info.
+  // Populated for graph inputs (from FreeDimensionBounds) and Reshape outputs (derived dims).
+  InlinedHashMap<std::string, OperandDimInfo> operand_dim_info_map_;
 
   uint32_t name_token_{0};
   InlinedHashSet<std::string> unique_names_;


### PR DESCRIPTION
1. Add `DynamicDimInfo` with numerator/denominator to track how Reshape scales dynamic dims (e.g., sequence_length x8,  /8). 
2. Build intermediate `MLDynamicDimension` descriptors for reshape, preferring real ONNX dim_param names.

3. Propagate dim info through shape-preserving ops. limitations:

  > - Only propagates from the first input (input_defs[0]). For binary ops like Add(A, B), if only B carries dim info, it won't be propagated.
  > - Only sets dim info on the first output (output_defs[0]). Multi-output ops may need dim info on additional outputs.
  > - Does not handle rank-changing ops.
  > - Axis-reordering ops (e.g., Transpose) have the same rank but permute axis semantics. Directly copying dim info would assign dynamic dims to wrong axes.
  